### PR TITLE
bug: maximize the window on macos

### DIFF
--- a/openai_helper/ui/app.py
+++ b/openai_helper/ui/app.py
@@ -15,7 +15,11 @@ class App(ThemedTk):
         super().__init__()
         self.configuration = Configuration(configuration_path)
         self.title("OpenAI Helper")
-        self.attributes("-zoomed", True)
+
+        # Maximize the window on all platforms
+        self.attributes("-zoomed", True)  # For Windows and Linux
+        self.wm_state("zoomed")  # For MacOS
+
         self._create_widgets()
 
     def _create_widgets(self):

--- a/openai_helper/ui/app.py
+++ b/openai_helper/ui/app.py
@@ -1,5 +1,6 @@
 """UI App"""
 
+import sys
 from pathlib import Path
 
 from ttkthemes import ThemedTk
@@ -17,8 +18,10 @@ class App(ThemedTk):
         self.title("OpenAI Helper")
 
         # Maximize the window on all platforms
-        self.attributes("-zoomed", True)  # For Windows and Linux
-        self.wm_state("zoomed")  # For MacOS
+        if sys.platform == "darwin":
+            self.wm_state("zoomed")  # For MacOS
+        else:
+            self.attributes("-zoomed", True)  # For Windows and Linux
 
         self._create_widgets()
 


### PR DESCRIPTION
`self.attributes("-zoomed, True)` didn't work for macos, I added `self.wm_state("zoomed")` to achieve the same result on macos. opens the window maximised in the currently open screen, not as a second screen.